### PR TITLE
[Reviewer: Ellie] Uploading Chronos GR Config requires root

### DIFF
--- a/chronos/scripts/upload_chronos_gr_config
+++ b/chronos/scripts/upload_chronos_gr_config
@@ -37,6 +37,8 @@ local_site_name=site1
 etcd_key=clearwater
 . /etc/clearwater/config
 
+. /usr/share/clearwater/utils/check-root-permissions 2
+
 # Check we can contact `etcd`
 if ! nc -z ${management_local_ip:-$local_ip} 4000
 then


### PR DESCRIPTION
This fixes issue #9 by using the script added in https://github.com/Metaswitch/clearwater-infrastructure/pull/381 to check for root permissions.

I've tested live on a Sprout node.
