### PR TITLE
[No reviewer] Update for cass_2.1.15. set rpc_broadcast_address to node IP

### DIFF
--- a/clearwater_cassandra/cassandra_plugin.py
+++ b/clearwater_cassandra/cassandra_plugin.py
@@ -123,6 +123,7 @@ class CassandraPlugin(SynchroniserPluginBase):
         # Fill in the correct listen_address and seeds values in the yaml
         # document.
         doc["listen_address"] = self._ip
+        doc["broadcast_rpc_address"] = self._ip
 
         doc["seed_provider"][0]["parameters"][0]["seeds"] = seeds_list_str
         doc["endpoint_snitch"] = "GossipingPropertyFileSnitch"


### PR DESCRIPTION
Change needed for https://github.com/Metaswitch/clearwater-cassandra/pull/107 to move to Cassandra 2.1.15