### PR TITLE
[Reviewer: Ellie] Create default files, plugins side

### DIFF
--- a/clearwater_config_manager/dns_config_plugin.py
+++ b/clearwater_config_manager/dns_config_plugin.py
@@ -73,5 +73,10 @@ class DnsConfigPlugin(ConfigPluginBase):
             safely_write(_file, value)
             run_command("/usr/share/clearwater/bin/reload_dns_config")
 
+    def on_creating_etcd_key(self, value):
+        if value != _default_value:
+            run_command("/usr/share/clearwater/bin/reload_dns_config")
+
+
 def load_as_plugin(params):  # pragma: no cover
     return DnsConfigPlugin(params)

--- a/clearwater_config_manager/dns_config_plugin.py
+++ b/clearwater_config_manager/dns_config_plugin.py
@@ -73,9 +73,5 @@ class DnsConfigPlugin(ConfigPluginBase):
             safely_write(_file, value)
             run_command("/usr/share/clearwater/bin/reload_dns_config")
 
-    def on_creating_etcd_key(self, value):
-        if value != _default_value:
-            run_command("/usr/share/clearwater/bin/reload_dns_config")
-
 def load_as_plugin(params):  # pragma: no cover
     return DnsConfigPlugin(params)

--- a/clearwater_config_manager/dns_config_plugin.py
+++ b/clearwater_config_manager/dns_config_plugin.py
@@ -77,6 +77,5 @@ class DnsConfigPlugin(ConfigPluginBase):
         if value != _default_value:
             run_command("/usr/share/clearwater/bin/reload_dns_config")
 
-
 def load_as_plugin(params):  # pragma: no cover
     return DnsConfigPlugin(params)

--- a/clearwater_config_manager/dns_config_plugin.py
+++ b/clearwater_config_manager/dns_config_plugin.py
@@ -36,6 +36,11 @@ import logging
 
 _log = logging.getLogger("dns_config_plugin")
 _file = "/etc/clearwater/dns_config"
+_default_value = """\
+{
+  "hostnames": [
+  ]
+}"""
 
 class DnsConfigPlugin(ConfigPluginBase):
     def __init__(self, _params):
@@ -46,6 +51,9 @@ class DnsConfigPlugin(ConfigPluginBase):
 
     def file(self):
         return _file
+
+    def default_value(self):
+        return _default_value
 
     def status(self, value):
         try:

--- a/clearwater_config_manager/shared_config_plugin.py
+++ b/clearwater_config_manager/shared_config_plugin.py
@@ -39,7 +39,11 @@ import os
 
 _log = logging.getLogger("shared_config_plugin")
 _file = "/etc/clearwater/shared_config"
-_default_value = "### Create Shared Config Here ###"
+_default_value = """\
+#####################################################################
+# No Shared Config has been provided
+# Replace this file with the Shared Configuration for your deployment
+#####################################################################"""
 
 class SharedConfigPlugin(ConfigPluginBase):
     def __init__(self, _params):
@@ -70,12 +74,8 @@ class SharedConfigPlugin(ConfigPluginBase):
 
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)
-            run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
-
-    def on_creating_etcd_key(self, value):
-        if value != _default_value:
-            _log.debug("Created non-default config key in etcd. Adding node to restart queue")
-            run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
+            if value != _default_value:
+                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
 
 def load_as_plugin(params):  # pragma: no cover
     return SharedConfigPlugin(params)

--- a/clearwater_config_manager/shared_config_plugin.py
+++ b/clearwater_config_manager/shared_config_plugin.py
@@ -39,6 +39,7 @@ import os
 
 _log = logging.getLogger("shared_config_plugin")
 _file = "/etc/clearwater/shared_config"
+_default_value = ""
 
 class SharedConfigPlugin(ConfigPluginBase):
     def __init__(self, _params):
@@ -49,6 +50,9 @@ class SharedConfigPlugin(ConfigPluginBase):
 
     def file(self):
         return _file
+
+    def default_value(self):
+        return _default_value
 
     def status(self, value):
         try:

--- a/clearwater_config_manager/shared_config_plugin.py
+++ b/clearwater_config_manager/shared_config_plugin.py
@@ -39,7 +39,7 @@ import os
 
 _log = logging.getLogger("shared_config_plugin")
 _file = "/etc/clearwater/shared_config"
-_default_value = ""
+_default_value = "### Create Shared Config Here ###"
 
 class SharedConfigPlugin(ConfigPluginBase):
     def __init__(self, _params):
@@ -70,6 +70,11 @@ class SharedConfigPlugin(ConfigPluginBase):
 
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)
+            run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
+
+    def on_creating_etcd_key(self, value):
+        if value != _default_value:
+            _log.debug("Created non-default config key in etcd. Adding node to restart queue")
             run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
 
 def load_as_plugin(params):  # pragma: no cover

--- a/sprout/sprout_bgcf_json_plugin.py
+++ b/sprout/sprout_bgcf_json_plugin.py
@@ -47,5 +47,11 @@ class SproutBGCFJsonPlugin(SproutJsonPlugin):
     def __init__(self, _params):
         super(SproutBGCFJsonPlugin, self).__init__("/etc/clearwater/bgcf.json", "bgcf_json")
 
+    _default_value = """\
+    {
+        "routes" : [
+        ]
+    }"""
+
 def load_as_plugin(params):
     return SproutBGCFJsonPlugin(params)

--- a/sprout/sprout_bgcf_json_plugin.py
+++ b/sprout/sprout_bgcf_json_plugin.py
@@ -48,10 +48,10 @@ class SproutBGCFJsonPlugin(SproutJsonPlugin):
         super(SproutBGCFJsonPlugin, self).__init__("/etc/clearwater/bgcf.json", "bgcf_json")
 
     _default_value = """\
-    {
-        "routes" : [
-        ]
-    }"""
+{
+    "routes" : [
+    ]
+}"""
 
 def load_as_plugin(params):
     return SproutBGCFJsonPlugin(params)

--- a/sprout/sprout_enum_json_plugin.py
+++ b/sprout/sprout_enum_json_plugin.py
@@ -48,10 +48,10 @@ class SproutENUMJsonPlugin(SproutJsonPlugin):
         super(SproutENUMJsonPlugin, self).__init__("/etc/clearwater/enum.json", "enum_json")
 
     _default_value = """\
-    {
-        "routes" : [
-        ]
-    }"""
+{
+    "number_blocks" : [
+    ]
+}"""
 
 def load_as_plugin(params):
     return SproutENUMJsonPlugin(params)

--- a/sprout/sprout_enum_json_plugin.py
+++ b/sprout/sprout_enum_json_plugin.py
@@ -47,5 +47,11 @@ class SproutENUMJsonPlugin(SproutJsonPlugin):
     def __init__(self, _params):
         super(SproutENUMJsonPlugin, self).__init__("/etc/clearwater/enum.json", "enum_json")
 
+    _default_value = """\
+    {
+        "routes" : [
+        ]
+    }"""
+
 def load_as_plugin(params):
     return SproutENUMJsonPlugin(params)

--- a/sprout/sprout_json_plugin.py
+++ b/sprout/sprout_json_plugin.py
@@ -69,7 +69,3 @@ class SproutJsonPlugin(ConfigPluginBase):
         run_command("service sprout reload")
 
         alarm.update_file(self._file)
-
-    def on_creating_etcd_key(self, value):
-        if value != _default_value:
-            run_command("service sprout reload")

--- a/sprout/sprout_json_plugin.py
+++ b/sprout/sprout_json_plugin.py
@@ -47,6 +47,9 @@ class SproutJsonPlugin(ConfigPluginBase):
     def file(self):
         return self._file
 
+    def default_value(self):
+        return self._default_value
+
     def status(self, value):
         try:
             with open(self._file, "r") as ifile:

--- a/sprout/sprout_json_plugin.py
+++ b/sprout/sprout_json_plugin.py
@@ -69,3 +69,7 @@ class SproutJsonPlugin(ConfigPluginBase):
         run_command("service sprout reload")
 
         alarm.update_file(self._file)
+
+    def on_creating_etcd_key(self, value):
+        if value != _default_value:
+            run_command("service sprout reload")

--- a/sprout/sprout_scscf_json_plugin.py
+++ b/sprout/sprout_scscf_json_plugin.py
@@ -48,10 +48,10 @@ class SproutSCSCFJsonPlugin(SproutJsonPlugin):
         super(SproutSCSCFJsonPlugin, self).__init__("/etc/clearwater/s-cscf.json", "scscf_json")
 
     _default_value = """\
-    {
-        "s-cscfs" : [
-        ]
-    }"""
+{
+    "s-cscfs" : [
+    ]
+}"""
 
 def load_as_plugin(params):
     return SproutSCSCFJsonPlugin(params)

--- a/sprout/sprout_scscf_json_plugin.py
+++ b/sprout/sprout_scscf_json_plugin.py
@@ -47,5 +47,11 @@ class SproutSCSCFJsonPlugin(SproutJsonPlugin):
     def __init__(self, _params):
         super(SproutSCSCFJsonPlugin, self).__init__("/etc/clearwater/s-cscf.json", "scscf_json")
 
+    _default_value = """\
+    {
+        "s-cscfs" : [
+        ]
+    }"""
+
 def load_as_plugin(params):
     return SproutSCSCFJsonPlugin(params)


### PR DESCRIPTION
This is the plugins side of creating default files and inserting them into etcd if no key is present already.

Tested live, and correct files are created. Also used `curl http://127.0.0.1:4000/v2/keys/clearwater/single_site/configuration/<file key>` to check that the files had been added to etcd correctly.