### PR TITLE
[Reviewer: Ellie] Use fixed cassandra read timeout

### DIFF
--- a/clearwater_cassandra/cassandra_plugin.py
+++ b/clearwater_cassandra/cassandra_plugin.py
@@ -132,21 +132,9 @@ class CassandraPlugin(SynchroniserPluginBase):
         doc["seed_provider"][0]["parameters"][0]["seeds"] = seeds_list_str
         doc["endpoint_snitch"] = "GossipingPropertyFileSnitch"
 
-        # Work out the timeout from the target_latency_us value (assuming
-        # 100000 if it isn't set)
-        get_latency_cmd = "target_latency_us=100000; . /etc/clearwater/config; echo -n $target_latency_us"
-        latency = subprocess.check_output(get_latency_cmd,
-                                          shell=True,
-                                          stderr=subprocess.STDOUT)
-
-        try:
-            # We want the timeout value to be 4/5ths the maximum acceptable time
-            # of a HTTP request (which is 5 * target latency)
-            timeout = (int(latency) / 1000) * 4
-        except ValueError:  #  pragma: no cover
-            timeout = 400
-
-        doc["read_request_timeout_in_ms"] = timeout
+        # The read request timeout must not be higher than the Thrift connection
+        # timeout, which is currently set to 250ms
+        doc["read_request_timeout_in_ms"] = 230
 
         contents = WARNING_HEADER + "\n" + yaml.dump(doc)
         topology = WARNING_HEADER + "\n" + "dc={}\nrack=RAC1\n".format(self._local_site)


### PR DESCRIPTION
This is a fix for issue https://github.com/Metaswitch/clearwater-issues/issues/2092

As discussed, the problem here was that we've set our Thrift timeout to 250ms, but our Cassandra `read_request_timeout_in_ms` to 400ms. If the Vellum node that's down is one that holds a replica for the data being read, then the consistency level 2 read will timeout. Because our Thrift timeout is the shorter, instead of retrying the same Cassandra node with consistency level 1, we retry a different cassandra node with consistency level 2 (as we think that we're unable to contact the Cassandra node, rather than thinking that it's just unable to get the data).

By setting the Cassandra read timeout to less that the thrift timeout (where I've somewhat arbitrarily taken 20ms off the thrift timeout), we get a cassandra timeout and retry the same node with level 1.

Tested live on a 3-vellum system that was hitting this before, and with this fix we don't get the call failures (and do see in SAS that we're retrying the same node with level 1, as we should, and getting a response).

We spoke about changing homestead's error codes for connectivity timeouts too, which I've not done (as this fix seems to work on its own, and you said we've got a story to look at our retry behaviour more generally). I *think* that returning a 504 not a 503 on failing to contact two Vellum nodes should be safe, so if you think that's uncontroversial and we should just do it then I'll open another PR for that.