### PR TITLE
Apply-config-plugin uses multiple queues

### DIFF
--- a/clearwater_config_manager/shared_config_plugin.py
+++ b/clearwater_config_manager/shared_config_plugin.py
@@ -37,6 +37,7 @@ import logging
 import shutil
 import os
 import codecs
+import subprocess
 
 _log = logging.getLogger("shared_config_plugin")
 _file = "/etc/clearwater/shared_config"
@@ -76,7 +77,8 @@ class SharedConfigPlugin(ConfigPluginBase):
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)
             if value != _default_value:
-                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add apply_config")
+                apply_config_key = subprocess.check_output(["/usr/share/clearwater/clearwater-queue-manager/scripts/get_apply_config_key"])
+                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue add {}".format(apply_config_key))
 
 def load_as_plugin(params):  # pragma: no cover
     return SharedConfigPlugin(params)

--- a/clearwater_queue_manager/apply_config_plugin.py
+++ b/clearwater_queue_manager/apply_config_plugin.py
@@ -34,13 +34,15 @@ from metaswitch.clearwater.queue_manager.plugin_base import QueuePluginBase
 from metaswitch.clearwater.etcd_shared.plugin_utils import run_command
 import logging
 import os
+import subprocess
 
 _log = logging.getLogger("apply_config_plugin")
 
 class ApplyConfigPlugin(QueuePluginBase):
     def __init__(self, params):
         self._wait_plugin_complete = params.wait_plugin_complete
-        self._key = subprocess.check_output([".", "/usr/share/clearwater/clearwater-queue-manager/scripts/get_apply_config_key"])).decode('utf-8')
+        output = subprocess.check_output(["/usr/share/clearwater/clearwater-queue-manager/scripts/get_apply_config_key"])
+        self._key = output.decode('utf-8')
 
     def key(self):  # pragma: no cover
         return self._key
@@ -58,16 +60,13 @@ class ApplyConfigPlugin(QueuePluginBase):
             _log.info("Checking service health")
             if run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/check_node_health.py"):
                 _log.info("Services failed to restart successfully")
-                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue 
-                        remove_failure {}".format(self._key))
+                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue remove_failure {}".format(self._key))
             else:
                 _log.info("Services restarted successfully")
-                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue
-                        remove_success {}".format(self._key))
+                run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue remove_success {}".format(self._key))
         else:
             _log.info("Not checking service health")
-            run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue 
-                    remove_success {}".format(self._key))
+            run_command("/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue remove_success {}".format(self._key))
 
 def load_as_plugin(params):  # pragma: no cover
     return ApplyConfigPlugin(params)


### PR DESCRIPTION
1. Use bash script to get etcd-key for applying config based on single or multiple queues
2. Store the key as field in constructor so that it won't be changed
3. When the node is at the front of queue, it should modify nodes in queue using the right key instead of previous generic "apply_config"

Testing:
Will write a UT for adding node using multiple queues, and another UT for removing node.