### PR TITLE
Add ability to run scripts without sudo

### DIFF
--- a/clearwater_config_manager/scripts/display_fallback_ifcs
+++ b/clearwater_config_manager/scripts/display_fallback_ifcs
@@ -10,7 +10,6 @@
 local_site_name=site1
 etcd_key=clearwater
 . /etc/clearwater/config
-. /usr/share/clearwater/utils/check-root-permissions 1
 
 # Check we can contact `etcd`
 if ! nc -z ${management_local_ip:-$local_ip} 4000

--- a/clearwater_config_manager/scripts/display_shared_ifcs
+++ b/clearwater_config_manager/scripts/display_shared_ifcs
@@ -10,7 +10,6 @@
 local_site_name=site1
 etcd_key=clearwater
 . /etc/clearwater/config
-. /usr/share/clearwater/utils/check-root-permissions 1
 
 # Check we can contact `etcd`
 if ! nc -z ${management_local_ip:-$local_ip} 4000

--- a/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
@@ -10,8 +10,6 @@
 FILENAME=/etc/clearwater/fallback_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/fallback_ifcs_schema.xsd
 
-. /usr/share/clearwater/utils/check-root-permissions 1
-
 [ $# -le 1 ] || { echo "Usage: validate_fallback_ifcs_xml [file to validate] (defaults to $FILENAME if not specified)" >&2 ; exit 2 ; }
 [ -z "$1" ] || FILENAME=$1
 

--- a/clearwater_config_manager/scripts/validate_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_shared_ifcs_xml
@@ -10,8 +10,6 @@
 FILENAME=/etc/clearwater/shared_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/shared_ifcs_schema.xsd
 
-. /usr/share/clearwater/utils/check-root-permissions 1
-
 [ $# -le 1 ] || { echo "Usage: validate_shared_ifcs_config [file to validate] (defaults to $FILENAME if not specified)" >&2 ; exit 2 ; }
 [ -z "$1" ] || FILENAME=$1
 


### PR DESCRIPTION
I've done this for:
-validate_shared_ifcs_xml
-validate_fallback_ifcs_xml
-display_shared_ifcs
-display_fallback_ifcs

I've tested on a live box that these commands no longer require sudo, and the test passed.