### PR TITLE
[Reviewer: Krista] Add warning on upload

### DIFF
--- a/clearwater_config_manager/fallback_ifcs_xml_plugin.py
+++ b/clearwater_config_manager/fallback_ifcs_xml_plugin.py
@@ -42,7 +42,7 @@ class FallbackIFCsXMLPlugin(ConfigPluginBase):
             return FileStatus.MISSING
 
     def on_config_changed(self, value, alarm):
-        _log.info("Updating Fallback IFCs configuration file")
+        _log.info("Updating the fallback iFCs configuration file")
 
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)

--- a/clearwater_config_manager/scripts/remove_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/remove_fallback_ifcs_xml
@@ -25,11 +25,11 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo Unable to remove the fallback IFCs                 >&2
+  echo Unable to remove the fallback iFCs configuration   >&2
   cat /tmp/remove-fallback-ifcs-xml.stderr.$$             >&2
   cat /tmp/remove-fallback-ifcs-xml.stdout.$$             >&2
 else
-  echo Fallback IFCs removed
+  echo The fallback iFCs configuration has been removed
 fi
 
 rm -f /tmp/remove-fallback-ifcs-xml.stderr.$$ /tmp/remove-fallback-ifcs-xml.stdout.$$

--- a/clearwater_config_manager/scripts/remove_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/remove_shared_ifcs_xml
@@ -25,10 +25,10 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo Unable to remove the Shared IFCs                  >&2
-  cat /tmp/remove-shared-ifcs-xml.stderr.$$              >&2
-  cat /tmp/remove-shared-ifcs-xml.stdout.$$              >&2
+  echo Unable to remove the shared iFC sets configuration >&2
+  cat /tmp/remove-shared-ifcs-xml.stderr.$$               >&2
+  cat /tmp/remove-shared-ifcs-xml.stdout.$$               >&2
 else
-  echo Shared IFCs removed
+  echo The shared iFCs sets configuration has been removed
 fi
 rm -f /tmp/remove-shared-ifcs-xml.stderr.$$ /tmp/remove-shared-ifcs-xml.stdout.$$

--- a/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
@@ -11,6 +11,7 @@ FILENAME=/etc/clearwater/fallback_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/fallback_ifcs_schema.xsd
 local_site_name=site1
 etcd_key=clearwater
+apply_fallback_ifcs=Y
 . /etc/clearwater/config
 
 . /usr/share/clearwater/utils/check-root-permissions 1
@@ -38,7 +39,7 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo The fallback IFC file is invalid - unable to upload >&2
+  echo The fallback iFC file is invalid - unable to upload >&2
   cat /tmp/upload-fallback-ifcs-xml.stderr.$$              >&2
   rm -f /tmp/upload-fallback-ifcs-xml.stderr.$$ /tmp/upload-fallback-ifcs-xml.stdout.$$
   exit $rc
@@ -52,11 +53,20 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo Upload fallback IFCs configuration failed to $keypath  >&2
+  echo Upload fallback iFCs configuration failed to $keypath  >&2
   cat /tmp/upload-fallback-ifcs-xml.stderr.$$                 >&2
   cat /tmp/upload-fallback-ifcs-xml.stdout.$$                 >&2
+else
+  if [ $apply_fallback_ifcs != "Y" ]; then
+    echo "Uploading fallback iFCs, but fallback iFCs aren't being used by this deployment. To enable fallback iFCs, set apply_fallback_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration"
+  fi
+
+  # Call the reload_fallback_ifc_xml scripts on this node
+  /usr/share/clearwater/bin/reload_fallback_ifcs_xml
 fi
+
 rm -f /tmp/upload-fallback-ifcs-xml.stderr.$$ /tmp/upload-fallback-ifcs-xml.stdout.$$
+
 
 # Call the reload_fallback_ifc_xml scripts on this node
 /usr/share/clearwater/bin/reload_fallback_ifcs_xml

--- a/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
@@ -11,7 +11,7 @@ FILENAME=/etc/clearwater/fallback_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/fallback_ifcs_schema.xsd
 local_site_name=site1
 etcd_key=clearwater
-apply_fallback_ifcs=Y
+apply_fallback_ifcs=N
 . /etc/clearwater/config
 
 . /usr/share/clearwater/utils/check-root-permissions 1
@@ -57,8 +57,9 @@ if [ $rc != 0 ] ; then
   cat /tmp/upload-fallback-ifcs-xml.stderr.$$                 >&2
   cat /tmp/upload-fallback-ifcs-xml.stdout.$$                 >&2
 else
+  echo "Successfully uploaded new fallback iFCs configuration."
   if [ $apply_fallback_ifcs != "Y" ]; then
-    echo "Uploading fallback iFCs, but fallback iFCs aren't being used by this deployment. To enable fallback iFCs, set apply_fallback_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration"
+    echo "Fallback iFCs aren't being applied by the S-CSCF in this deployment. If this isn't what you expect, and you want to enable fallback iFCs, set apply_fallback_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration."
   fi
 
   # Call the reload_fallback_ifc_xml scripts on this node
@@ -66,8 +67,5 @@ else
 fi
 
 rm -f /tmp/upload-fallback-ifcs-xml.stderr.$$ /tmp/upload-fallback-ifcs-xml.stdout.$$
-
-# Call the reload_fallback_ifc_xml scripts on this node
-/usr/share/clearwater/bin/reload_fallback_ifcs_xml
 
 exit $rc

--- a/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/upload_fallback_ifcs_xml
@@ -67,7 +67,6 @@ fi
 
 rm -f /tmp/upload-fallback-ifcs-xml.stderr.$$ /tmp/upload-fallback-ifcs-xml.stdout.$$
 
-
 # Call the reload_fallback_ifc_xml scripts on this node
 /usr/share/clearwater/bin/reload_fallback_ifcs_xml
 

--- a/clearwater_config_manager/scripts/upload_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/upload_shared_ifcs_xml
@@ -11,6 +11,7 @@ FILENAME=/etc/clearwater/shared_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/shared_ifcs_schema.xsd
 local_site_name=site1
 etcd_key=clearwater
+request_shared_ifcs=Y
 . /etc/clearwater/config
 
 . /usr/share/clearwater/utils/check-root-permissions 1
@@ -38,7 +39,7 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo The shared IFC file is invalid - unable to upload >&2
+  echo The shared iFC sets file is invalid - unable to upload >&2
   cat /tmp/upload-shared-ifcs-xml.stderr.$$              >&2
   rm -f /tmp/upload-shared-ifcs-xml.stderr.$$ /tmp/upload-shared-ifcs-xml.stdout.$$
   exit $rc
@@ -52,13 +53,17 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo Upload shared IFCs configuration failed to $keypath  >&2
+  echo Upload shared iFC sets configuration failed to $keypath  >&2
   cat /tmp/upload-shared-ifcs-xml.stderr.$$                 >&2
   cat /tmp/upload-shared-ifcs-xml.stdout.$$                 >&2
+else
+  if [ $request_shared_ifcs != "Y" ]; then
+    echo "Uploading shared iFC sets, but shared iFC sets aren't being requested from the HSS by this deployment. To enable shared iFC sets, set request_shared_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration"
+  fi
+
+  # Call the reload_shared_ifc_xml scripts on this node
+  /usr/share/clearwater/bin/reload_shared_ifcs_xml
 fi
 rm -f /tmp/upload-shared-ifcs-xml.stderr.$$ /tmp/upload-shared-ifcs-xml.stdout.$$
-
-# Call the reload_shared_ifc_xml scripts on this node
-/usr/share/clearwater/bin/reload_shared_ifcs_xml
 
 exit $rc

--- a/clearwater_config_manager/scripts/upload_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/upload_shared_ifcs_xml
@@ -11,7 +11,7 @@ FILENAME=/etc/clearwater/shared_ifcs.xml
 SCHEMA=/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/shared_ifcs_schema.xsd
 local_site_name=site1
 etcd_key=clearwater
-request_shared_ifcs=Y
+request_shared_ifcs=N
 . /etc/clearwater/config
 
 . /usr/share/clearwater/utils/check-root-permissions 1
@@ -57,13 +57,15 @@ if [ $rc != 0 ] ; then
   cat /tmp/upload-shared-ifcs-xml.stderr.$$                 >&2
   cat /tmp/upload-shared-ifcs-xml.stdout.$$                 >&2
 else
+  echo "Successfully uploaded new shared iFC sets configuration."
   if [ $request_shared_ifcs != "Y" ]; then
-    echo "Uploading shared iFC sets, but shared iFC sets aren't being requested from the HSS by this deployment. To enable shared iFC sets, set request_shared_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration"
+    echo "Shared iFC sets aren't being requested from the HSS by this deployment. If this isn't what you expect, and you want to enable shared iFC sets, set request_shared_ifcs=Y in /etc/clearwater/shared_config, and follow the documented process to modify Clearwater configuration."
   fi
 
   # Call the reload_shared_ifc_xml scripts on this node
   /usr/share/clearwater/bin/reload_shared_ifcs_xml
 fi
+
 rm -f /tmp/upload-shared-ifcs-xml.stderr.$$ /tmp/upload-shared-ifcs-xml.stdout.$$
 
 exit $rc

--- a/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
@@ -25,10 +25,10 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo The fallback IFC file is invalid                    >&2
+  echo The fallback iFCs configuration is invalid          >&2
   cat /tmp/validate-fallback-ifcs-xml.stderr.$$            >&2
 else
-  echo The fallback IFC file is valid
+  echo The fallback iFCs configuration is valid
 fi
 
 rm -f /tmp/validate-fallback-ifcs-xml.stderr.$$ /tmp/validate-fallback-ifcs-xml.stdout.$$

--- a/clearwater_config_manager/scripts/validate_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_shared_ifcs_xml
@@ -25,10 +25,10 @@ rc=$?
 
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
-  echo The Shared IFC file is invalid                    >&2
+  echo The shared iFC sets configuration is invalid      >&2
   cat /tmp/validate-shared-ifcs-xml.stderr.$$            >&2
 else
-  echo The Shared IFC file is valid
+  echo The shared iFC sets configuration is valid
 fi
 rm -f /tmp/validate-shared-ifcs-xml.stderr.$$ /tmp/validate-shared-ifcs-xml.stdout.$$
 

--- a/clearwater_config_manager/shared_ifcs_xml_plugin.py
+++ b/clearwater_config_manager/shared_ifcs_xml_plugin.py
@@ -42,7 +42,7 @@ class SharedIFCsXMLPlugin(ConfigPluginBase):
             return FileStatus.MISSING
 
     def on_config_changed(self, value, alarm):
-        _log.info("Updating Shared IFCs configuration file")
+        _log.info("Updating the shared iFC sets configuration file")
 
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)


### PR DESCRIPTION
The PR adds a warning if you try and upload shared IFCs/fallback IFCs and the relevant config option isn't set.

I've also tidied up some of the inconsistencies with iFC/IFC.

I've not tested this yet, but I'll live test it before checking it in.