### PR TITLE
[Reviewer: KH1] Corrected error handling for shared_ifcs.

### DIFF
--- a/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_fallback_ifcs_xml
@@ -26,7 +26,7 @@ rc=$?
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
   echo The fallback iFC sets file is invalid.                        >&2
-  cat /tmp/upload-fallback-ifcs-xml.stderr.$$ | grep -v "Loaded URL" >&2
+  cat /tmp/validate-fallback-ifcs-xml.stderr.$$ | grep -v "Loaded URL" >&2
 else
   echo The fallback iFCs configuration is valid.
 fi

--- a/clearwater_config_manager/scripts/validate_shared_ifcs_xml
+++ b/clearwater_config_manager/scripts/validate_shared_ifcs_xml
@@ -26,7 +26,7 @@ rc=$?
 # Check the return code and log if appropriate.
 if [ $rc != 0 ] ; then
   echo The shared iFC sets file is invalid.                        >&2
-  cat /tmp/upload-shared-ifcs-xml.stderr.$$ | grep -v "Loaded URL" >&2
+  cat /tmp/validate-shared-ifcs-xml.stderr.$$ | grep -v "Loaded URL" >&2
 else
   echo The shared iFC sets configuration is valid.
 fi


### PR DESCRIPTION
Hi Krista, 

I have made changes so that 'validate_shared_ifcs_xml' and 'validate_fallback_ifcs_xml' call the correct script files when handling errors. Would you mind reviewing it?

Prior to the fix, running the command 'cw-validate_shared_ifcs_xml' with the config file /etc/clearwater/shared_ifcs.xml containing the following block
...
        \<RegistrationType>0\</RegistrationType>
        \<RegistrationType>1\</RegistrationType>
        \<RegistrationType>2\</RegistrationType>
...
gave the following error message:
    The shared iFC sets file is invalid.
    cat: /tmp/upload-shared-ifcs-xml.stderr.22675: No such file or directory

After the fix, a more useful error message is given:
    The shared iFC sets file is invalid.
    /etc/clearwater/shared_ifcs.xml:16: element RegistrationType: Schemas validity error : Element 
    'RegistrationType': This element is not expected. Expected is ( Extension ).