### PR TITLE
Add new rph.json config

### DIFF
--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -13,6 +13,7 @@ from metaswitch.clearwater.config_manager.config_type_class_plugin import Config
 LOG_DIR = "/var/log/clearwater-config-manager"
 log = logging.getLogger("cw-config.validate")
 
+
 class RphJson(ConfigType):
     def __init__(self, configpath):
         """ Initialise the class variables. """
@@ -25,14 +26,13 @@ class RphJson(ConfigType):
         # when writing to file
         self.file_download_name = 'rph.json'
 
-        # This help_info appears as user-visible help text in the usage statement
-        # for cw-config.
+        # This help_info appears as user-visible help text in the usage
+        # statement for cw-config.
         self.help_info = ('''rph_json - maps different resource priority header
-                values to an internal priority value.''')
+                             values to an internal priority value.''')
 
         self.schema = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_schema.json'
         self.validation_file = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py'
-
 
     def validate(self):
         """ Validate using custom validation script. """

--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -37,7 +37,7 @@ class RphJson(ConfigType):
     def validate(self):
         """ Validate using custom validation script. """
         validate_script = ['python', self.validation_file, self.schema,
-                            self.configfile]
+                           self.configfile]
         failed_scripts = []
         error_lines = []
 

--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -1,0 +1,63 @@
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+"""This contains the rph json subclass of ConfigType"""
+
+import subprocess
+import logging
+from metaswitch.clearwater.config_manager.config_type_class_plugin import ConfigType
+LOG_DIR = "/var/log/clearwater-config-manager"
+log = logging.getLogger("cw-config.validate")
+
+class RphJson(ConfigType):
+    def __init__(self, configpath):
+        """ Initialise the class variables. """
+        self.configfile = configpath
+
+        self.name = 'rph_json'
+        self.filetype = 'json'
+
+        # file_download_name is used to agree with the current naming system
+        # when writing to file
+        self.file_download_name = 'rph.json'
+
+        # This help_info appears as user-visible help text in the usage statement
+        # for cw-config.
+        self.help_info = ('''rph_json - maps different resource priority header
+                values to an internal priority value.''')
+
+        self.schema = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_schema.json'
+        self.validation_file = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py'
+
+
+    def validate(self):
+        """ Validate using custom validation script. """
+        validate_script = ['python', self.validation_file, self.schema,
+                            self.configfile]
+        failed_scripts = []
+        error_lines = []
+
+        try:
+            log.debug("Running validation script rph_validation.py")
+            subprocess.check_output(validate_script, stderr=subprocess.STDOUT)
+        except subprocess.CalledProcessError as exc:
+            log.error("Validation script rph_validation.py failed")
+            log.error("Reasons for failure:")
+
+            errors = exc.output.splitlines()
+            error_lines.extend(errors)
+
+            for line in errors:
+                log.error(line)
+
+            failed_scripts.append('rph_validation.py')
+
+        return failed_scripts, error_lines
+
+
+def load_as_plugin(params):  # pragma: no cover
+    return RphJson(params)

--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -29,7 +29,7 @@ class RphJson(ConfigType):
         # This help_info appears as user-visible help text in the usage
         # statement for cw-config.
         self.help_info = ('''rph_json - maps different resource priority header
-                             values to an internal priority value.''')
+                values to an internal priority value.''')
 
         self.schema = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_schema.json'
         self.validation_file = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py'

--- a/clearwater_config_manager/rph_json_plugin.py
+++ b/clearwater_config_manager/rph_json_plugin.py
@@ -1,0 +1,113 @@
+# Copyright (C) Metaswitch Networks
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+from metaswitch.clearwater.config_manager.plugin_base import ConfigPluginBase, FileStatus
+from metaswitch.clearwater.etcd_shared.plugin_utils import run_command, safely_write
+import logging
+
+_log = logging.getLogger("rph_json_plugin")
+_file = "/etc/clearwater/rph.json"
+_default_value = """\
+{
+    "priority_blocks": [
+        {
+            "priority" : 1,
+            "rph_values" : []
+        },
+        {
+            "priority" : 2,
+            "rph_values" : []
+        },
+        {
+            "priority" : 3,
+            "rph_values" : []
+        },
+        {
+            "priority" : 4,
+            "rph_values" : []
+        },
+        {
+            "priority" : 5,
+            "rph_values" : []
+        },
+        {
+            "priority" : 6,
+            "rph_values" : []
+        },
+        {
+            "priority" : 7,
+            "rph_values" : []
+        },
+        {
+            "priority" : 8,
+            "rph_values" : []
+        },
+        {
+            "priority" : 9,
+            "rph_values" : []
+        },
+        {
+            "priority" : 10,
+            "rph_values" : []
+        },
+        {
+            "priority" : 11,
+            "rph_values" : []
+        },
+        {
+            "priority" : 12,
+            "rph_values" : []
+        },
+        {
+            "priority" : 13,
+            "rph_values" : []
+        },
+        {
+            "priority" : 14,
+            "rph_values" : []
+        },
+        {
+            "priority" : 15,
+            "rph_values" : []
+        }
+    ]
+}"""
+
+class RPHJSONPlugin(ConfigPluginBase):
+    def __init__(self, _params):
+        pass
+
+    def key(self):  # pragma: no cover
+        return "rph_json"
+
+    def file(self):
+        return _file
+
+    def default_value(self):
+        return _default_value
+
+    def status(self, value):
+        try:
+            with open(_file, "r") as ifile:
+                current = ifile.read()
+                if current == value:
+                    return FileStatus.UP_TO_DATE
+                else:
+                    return FileStatus.OUT_OF_SYNC
+        except IOError:  # pragma: no cover
+            return FileStatus.MISSING
+
+    def on_config_changed(self, value, alarm):
+        _log.info("Updating RPH configuration file")
+
+        if self.status(value) != FileStatus.UP_TO_DATE:
+            safely_write(_file, value)
+            run_command(["/usr/share/clearwater/bin/reload_rph_json"])
+            alarm.update_file(_file)
+
+def load_as_plugin(params):  # pragma: no cover
+    return RPHJSONPlugin(params)

--- a/sprout/sprout_rph_json_plugin.py
+++ b/sprout/sprout_rph_json_plugin.py
@@ -77,6 +77,7 @@ _default_value = """\
     ]
 }"""
 
+
 class RPHJSONPlugin(ConfigPluginBase):
     def __init__(self, _params):
         pass
@@ -108,6 +109,7 @@ class RPHJSONPlugin(ConfigPluginBase):
             safely_write(_file, value)
             run_command(["/usr/share/clearwater/bin/reload_rph_json"])
             alarm.update_file(_file)
+
 
 def load_as_plugin(params):  # pragma: no cover
     return RPHJSONPlugin(params)

--- a/sprout/sprout_rph_json_plugin.py
+++ b/sprout/sprout_rph_json_plugin.py
@@ -19,7 +19,7 @@ class SproutRPHJsonPlugin(SproutJsonPlugin):
     def __init__(self, _params):
         super(SproutRPHJsonPlugin, self).__init__("/etc/clearwater/rph.json",
                                                   "rph_json")
-        _default_value = """\
+    _default_value = """\
 {
     "priority_blocks": [
         {

--- a/sprout/sprout_rph_json_plugin.py
+++ b/sprout/sprout_rph_json_plugin.py
@@ -14,6 +14,7 @@ sys.path.append(os.path.dirname(__file__))
 
 _log = logging.getLogger("sprout_rph_json_plugin")
 
+
 class SproutRPHJsonPlugin(SproutJsonPlugin):
     def __init__(self, _params):
         super(SproutRPHJsonPlugin, self).__init__("/etc/clearwater/rph.json",


### PR DESCRIPTION
Details in pull request https://github.com/Metaswitch/clearwater-etcd/pull/535.

The reason RphJson requires its own `__init__` and `validate` functions is that the ConfigType class was too restrictive.
Reworking the ConfigType class, and editing it's child classes (such as RphJson) is left as technical debt - I plan to talk to CNE/ENH about fixing these up.