### PR TITLE
Fix indentation issue in cw-config --help

### DIFF
--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -29,7 +29,7 @@ class RphJson(ConfigType):
         # This help_info appears as user-visible help text in the usage
         # statement for cw-config.
         self.help_info = ('''rph_json - maps different resource priority header
-                values to an internal priority value.''')
+              values to an internal priority value.''')
 
         self.schema = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_schema.json'
         self.validation_file = '/usr/share/clearwater/clearwater-config-manager/scripts/config_validation/rph_validation.py'


### PR DESCRIPTION
Fix to issue Metaswitch/clearwater-issues#2804

Live test

Now this is seen, with correct indentation:
```
[sprout-1]ubuntu@ec2-54-87-197-114:/usr/share/clearwater/clearwater-config-access/plugins$ cw-config --help
usage: cw-config [-h] [--autoconfirm] [--force] [--log-level LOG_LEVEL]
                 action config_type

positional arguments:
  action                The action to perform - {upload | download}
  config_type           shared_ifcs - this is the xml file which has a list of
                                      iFCs used by many subscribers.
                        shared_config - contains cluster wide general shared
                                      configuration.
                        fallback_ifcs - this is the xml file which is used if no
                                      relevant iFC can be found for a subscriber.
                        dns_json - sets up DNS overrides to CNAME records so that you
                                      can use a single hostname across the deployment.
                        scscf_json - this stores the configuration, capabilities,
                                      relative weightings and priority of each S-CSCF.
                        rph_json - maps different resource priority header
                                      values to an internal priority value.
                        enum_json - allows you to use file based ENUM, which translates
                                      dialed telephone numbers into resolvable SIP URIs.

optional arguments:
  -h, --help            show this help message and exit
  --autoconfirm         Turns autoconfirm on [default=off]
  --force               Turns forcing on [default=off]
  --log-level LOG_LEVEL
                        Set to 10 for DEBUG,
                            Set to 20 for INFO,
                            Set to 30 for WARNING,
                            Set to 40 for ERROR,
                            Set to 50 for CRITICAL.
                            All logs of this level or above will be
                            written to file.
                            DEFAULT is INFO
[sprout-1]ubuntu@ec2-54-87-197-114:/usr/share/clearwater/clearwater-config-access/plugins$
```


Before fix, this was seen (with incorrect indentation):
```
[sprout-1]ubuntu@ec2-54-87-197-114:/usr/share/clearwater/clearwater-config-access/plugins$ cw-config --help
usage: cw-config [-h] [--autoconfirm] [--force] [--log-level LOG_LEVEL]
                 action config_type

positional arguments:
  action                The action to perform - {upload | download}
  config_type           shared_ifcs - this is the xml file which has a list of
                                      iFCs used by many subscribers.
                        shared_config - contains cluster wide general shared
                                      configuration.
                        fallback_ifcs - this is the xml file which is used if no
                                      relevant iFC can be found for a subscriber.
                        dns_json - sets up DNS overrides to CNAME records so that you
                                      can use a single hostname across the deployment.
                        scscf_json - this stores the configuration, capabilities,
                                      relative weightings and priority of each S-CSCF.
                        rph_json - maps different resource priority header
                                        values to an internal priority value.
                        enum_json - allows you to use file based ENUM, which translates
                                      dialed telephone numbers into resolvable SIP URIs.

optional arguments:
  -h, --help            show this help message and exit
  --autoconfirm         Turns autoconfirm on [default=off]
  --force               Turns forcing on [default=off]
  --log-level LOG_LEVEL
                        Set to 10 for DEBUG,
                            Set to 20 for INFO,
                            Set to 30 for WARNING,
                            Set to 40 for ERROR,
                            Set to 50 for CRITICAL.
                            All logs of this level or above will be
                            written to file.
                            DEFAULT is INFO
[sprout-1]ubuntu@ec2-54-87-197-114:/usr/share/clearwater/clearwater-config-access/plugins$
```