### PR TITLE
Updates rph_json_config_plugin for the changes to the validate method

### DIFF
--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -40,10 +40,16 @@ class RphJson(ConfigType):
                            self.configfile]
         failed_scripts = []
         error_lines = []
+        passed_scripts = []
+        success_lines = []
 
         try:
             log.debug("Running validation script rph_validation.py")
-            subprocess.check_output(validate_script, stderr=subprocess.STDOUT)
+            output = subprocess.check_output(validate_script,
+                                             stderr=subprocess.STDOUT)
+            out_msg = output.splitlines()
+            success_lines.extend(out_msg)
+            passed_scripts.append("rph_validation.py")
         except subprocess.CalledProcessError as exc:
             log.error("Validation script rph_validation.py failed")
             log.error("Reasons for failure:")
@@ -56,7 +62,7 @@ class RphJson(ConfigType):
 
             failed_scripts.append('rph_validation.py')
 
-        return failed_scripts, error_lines
+        return failed_scripts, error_lines, passed_scripts, success_lines
 
 
 def load_as_plugin(params):  # pragma: no cover


### PR DESCRIPTION
I have changed the validate function to match the changes I have made to the validate in the base class. This is to allow you to print the successful scripts and also some scripts have useful output even if they pass.
These changes have been made to the validate function in the base class here: https://github.com/Metaswitch/clearwater-etcd/pull/547

I realise the rph validation doesn't print anything so they bits where it collects the `output` to `out_msg` are unnecessary but I thought it was better for it to match the overall format where possible 