### PR TITLE
[Reviewer: KAF] Fix up RPH config access plugin to use new interface

### DIFF
--- a/clearwater_config_access/rph_json_config_plugin.py
+++ b/clearwater_config_access/rph_json_config_plugin.py
@@ -39,30 +39,24 @@ class RphJson(ConfigType):
         validate_script = ['python', self.validation_file, self.schema,
                            self.configfile]
         failed_scripts = []
-        error_lines = []
         passed_scripts = []
-        success_lines = []
 
         try:
-            log.debug("Running validation script rph_validation.py")
-            output = subprocess.check_output(validate_script,
-                                             stderr=subprocess.STDOUT)
-            out_msg = output.splitlines()
-            success_lines.extend(out_msg)
+            msg = "Running validation script rph_validation.py"
+            log.debug(msg)
+            print(msg)
+            output = subprocess.check_call(validate_script,
+                                           stderr=subprocess.STDOUT)
             passed_scripts.append("rph_validation.py")
+
         except subprocess.CalledProcessError as exc:
-            log.error("Validation script rph_validation.py failed")
-            log.error("Reasons for failure:")
-
-            errors = exc.output.splitlines()
-            error_lines.extend(errors)
-
-            for line in errors:
-                log.error(line)
-
+            rc = exc.returncode
+            log.error("Validation script rph_validation.py failed with code {}".format(rc))
             failed_scripts.append('rph_validation.py')
 
-        return failed_scripts, error_lines, passed_scripts, success_lines
+        print("")
+
+        return failed_scripts, passed_scripts
 
 
 def load_as_plugin(params):  # pragma: no cover


### PR DESCRIPTION
This fixes the RPH config access plugin to conform to the new interface introduced in : https://github.com/Metaswitch/clearwater-etcd/pull/573/files

We now print stdout to the screen as the validation is run, and we don't collect and return the error or success lines.

It requires the corresponding change: https://github.com/Metaswitch/clearwater-etcd/pull/574

I've checked that `make full_test` passes, and I've live tested uploading valid rph_json and it works (and invalid rph_json is correctly rejected).