### PR TITLE
[Reviewer:Seb] Update the SAS config plugin, to trigger a restart when sas.json is changed

### DIFF
--- a/clearwater_config_manager/sas_json_plugin.py
+++ b/clearwater_config_manager/sas_json_plugin.py
@@ -76,8 +76,13 @@ class SASJSONPlugin(ConfigPluginBase):
 
         if self.status(value) != FileStatus.UP_TO_DATE:
             safely_write(_file, value)
+
             run_command(["/usr/share/clearwater/infrastructure/scripts/sas_socket_factory"])
-            run_command(["/usr/share/clearwater/bin/reload_sas_json"])
+
+            apply_config_key = subprocess.check_output(["/usr/share/clearwater/clearwater-queue-manager/scripts/get_apply_config_key"])
+            run_command(["/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue",
+                         "add", apply_config_key])
+
             alarm.update_file(_file)
 
 def resolve_domain_address(addr, dns_server=None): # pragma: no cover

--- a/clearwater_config_manager/sas_json_plugin.py
+++ b/clearwater_config_manager/sas_json_plugin.py
@@ -78,7 +78,6 @@ class SASJSONPlugin(ConfigPluginBase):
             safely_write(_file, value)
 
             run_command(["/usr/share/clearwater/infrastructure/scripts/sas_socket_factory"])
-
             apply_config_key = subprocess.check_output(["/usr/share/clearwater/clearwater-queue-manager/scripts/get_apply_config_key"])
             run_command(["/usr/share/clearwater/clearwater-queue-manager/scripts/modify_nodes_in_queue",
                          "add", apply_config_key])


### PR DESCRIPTION
Currently, uploading new sas.json triggers a reload, but this doesn't do anything as when the SAS server is updated we need to re-initiate

I still need to update the Unit tests in clearwater-etcd, but I've updated a Sprout node with new debian packages and sanity checked that uploading new config triggers a quiesce